### PR TITLE
update_post_to_recipeDetail_page

### DIFF
--- a/front/app/posts/page.tsx
+++ b/front/app/posts/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import axios from 'axios';
+import Link from 'next/link'; // Linkをインポート
 
 interface Recipe {
   id: number;
@@ -45,7 +46,9 @@ const PostsPage = () => {
         <ul>
           {results.map((recipe) => (
             <li key={recipe.id}>
-              <h2>{recipe.title}</h2>
+              <Link href={`/recipes/${recipe.id}`}> {/* レシピ詳細ページへのリンク */}
+                <h2>{recipe.title}</h2>
+              </Link>
               <p>{recipe.description}</p>
             </li>
           ))}


### PR DESCRIPTION
# 実装した機能
詳細表示機能を既存の投稿一覧から表示できるようにしました。

# 再現方法
http://localhost:4000/posts?keyword=%E3%83%91%E3%82%B9%E3%82%BFなど存在するレシピの名前を押下

# 期待する挙動
レシピ名、カテゴリ、調理時間:、費用、説明文、材料、作り方、タグが表示される